### PR TITLE
Fix a Minor Issue with DappLooker's API Output Format

### DIFF
--- a/macros/marketplace/dapplooker/udfs.yaml.sql
+++ b/macros/marketplace/dapplooker/udfs.yaml.sql
@@ -14,7 +14,7 @@
     SELECT
       live.udf_api(
         'GET',
-        concat('https://api.dapplooker.com/chart/', CHART_ID, '?api_key={API_KEY}&format=json'),
+        concat('https://api.dapplooker.com/chart/', CHART_ID, '?api_key={API_KEY}&output_format=json'),
         {},
         {},
         '_FSC_SYS/DAPPLOOKER'


### PR DESCRIPTION
The DappLooker integration was using the wrong query parameter (`output` instead of `output_format`). I updated `output=json` to `output_format=json` to ensure the response is JSON.