### PR TITLE
AN-4230/decode-udfs

### DIFF
--- a/macros/core/utils.yaml.sql
+++ b/macros/core/utils.yaml.sql
@@ -238,4 +238,27 @@
     RETURNS NULL ON NULL INPUT
   sql: evm/decode/log
 
+- name: {{ schema }}.udf_hex_to_base58
+  signature:
+    - [hex, STRING]
+  return_type: TEXT
+  options: |
+    LANGUAGE PYTHON
+    RUNTIME_VERSION = '3.8'
+    HANDLER = 'transform_hex_to_base58'
+  sql: |
+    {{ create_udf_hex_to_base58() | indent(4) }}
+
+- name: {{ schema }}.udf_hex_to_bech32
+  signature:
+    - [hex, STRING]
+    - [hrp, STRING]
+  return_type: TEXT
+  options: |
+    LANGUAGE PYTHON
+    RUNTIME_VERSION = '3.8'
+    HANDLER = 'transform_hex_to_bech32'
+  sql: |
+    {{ create_udf_hex_to_bech32() | indent(4) }}
+
 {% endmacro %}


### PR DESCRIPTION
1. Adds `udf_hex_to_base58` and `udf_hex_to_bech32` 
2. Requires deploy cmd `dbt run -m models/deploy/core/utils.sql --vars '{"UPDATE_UDFS_AND_SPS":true, DROP_UDFS_AND_SPS: false}'`
3. docs review: https://app.gitbook.com/o/-LdEn7uFmFX9w2zbU4Eu/s/-LdEnDLYh6Su5z7LbnEZ/~/changes/492/live-query/examples/utility-functions/hex-converters