### PR TITLE
Stream 827/add max batch rows opt

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -71,6 +71,7 @@ vars:
   API_INTEGRATION: '{{ var("config")[target.name]["API_INTEGRATION"] }}'
   EXTERNAL_FUNCTION_URI: '{{ var("config")[target.name]["EXTERNAL_FUNCTION_URI"] }}'
   ROLES: '{{ var("config")[target.name]["ROLES"] }}'
+  API_INTEGRATION_OPTIONS: '{{ var("config")[target.name]["API_INTEGRATION_OPTIONS"] }}'
 
   config:
   # The keys correspond to dbt profiles and are case sensitive

--- a/macros/core/_live.yaml.sql
+++ b/macros/core/_live.yaml.sql
@@ -11,6 +11,7 @@
   return_type: VARIANT
   func_type: EXTERNAL
   api_integration: '{{ var("API_INTEGRATION") }}'
+  api_integration_options : '{{ var("API_INTEGRATION_OPTIONS") }}'
   options: |
     NOT NULL
     RETURNS NULL ON NULL INPUT

--- a/macros/livequery/manage_udfs.sql
+++ b/macros/livequery/manage_udfs.sql
@@ -33,7 +33,8 @@
         sql_,
         api_integration = none,
         options = none,
-        func_type = none
+        func_type = none,
+        api_integration_options = none
     ) %}
     CREATE OR REPLACE {{ func_type }} FUNCTION {{ name_ }}(
             {{- compile_signature(signature) }}
@@ -45,6 +46,8 @@
     {% endif %}
     {%- if api_integration -%}
     api_integration = {{ api_integration }}
+    {% if api_integration_options %}
+        {{ api_integration_options }}
     AS {{ construct_api_route(sql_) ~ ";" }}
     {% else -%}
     AS
@@ -65,6 +68,7 @@
     {% set options = config ["options"] %}
     {% set api_integration = config ["api_integration"] %}
     {% set func_type = config ["func_type"] %}
+    {% set api_integration_options = config ["api_integration_options"] if config ["api_integration_options"] else none%}
 
     {% if not drop_ -%}
         {{ create_sql_function(
@@ -74,6 +78,7 @@
             sql_ = sql_,
             options = options,
             api_integration = api_integration,
+            api_integration_options = api_integration_options,
             func_type = func_type
         ) }}
     {%- else -%}

--- a/macros/livequery/manage_udfs.sql
+++ b/macros/livequery/manage_udfs.sql
@@ -46,8 +46,9 @@
     {% endif %}
     {%- if api_integration -%}
     api_integration = {{ api_integration }}
-    {% if api_integration_options %}
-        {{ api_integration_options }}
+        {% if api_integration_options %}
+            {{ api_integration_options }}
+        {% endif %}
     AS {{ construct_api_route(sql_) ~ ";" }}
     {% else -%}
     AS

--- a/macros/livequery/manage_udfs.sql
+++ b/macros/livequery/manage_udfs.sql
@@ -68,7 +68,7 @@
     {% set options = config ["options"] %}
     {% set api_integration = config ["api_integration"] %}
     {% set func_type = config ["func_type"] %}
-    {% set api_integration_options = config ["api_integration_options"] if config ["api_integration_options"] else none%}
+    {% set api_integration_options = config ["api_integration_options"] if config ["api_integration_options"] else none %}
 
     {% if not drop_ -%}
         {{ create_sql_function(


### PR DESCRIPTION
Enables setting [MAX_BATCH_ROWS](https://docs.snowflake.com/en/sql-reference/sql/create-external-function) udf config for UDF's

- Adds `API_INTEGRATION_OPTIONS` var to `dbt_project.yml`, sets to None as default
- Adds `API_INTEGRATION_OPTIONS` attribute to `_live.yaml` config and macro
