### PR TITLE
STREAM-844 Refactor macros/core/live.yaml.sql options and add null support in udf_api

### DIFF
--- a/macros/core/_live.yaml.sql
+++ b/macros/core/_live.yaml.sql
@@ -13,6 +13,5 @@
   api_integration: '{{ var("API_INTEGRATION") }}'
   options: |
     NOT NULL
-    RETURNS NULL ON NULL INPUT
   sql: udf_api
 {% endmacro %}

--- a/macros/core/live.yaml.sql
+++ b/macros/core/live.yaml.sql
@@ -127,8 +127,8 @@
   func_type: EXTERNAL
   api_integration: '{{ var("API_INTEGRATION") }}'
   options: |
-    VOLATILE
     RETURNS NULL ON NULL INPUT
+    VOLATILE
     COMMENT = $$Returns a list of allowed domains.$$
   sql: allowed
 {% endmacro %}

--- a/macros/core/live.yaml.sql
+++ b/macros/core/live.yaml.sql
@@ -9,8 +9,6 @@
     - [secret_name, STRING]
   return_type: VARIANT
   options: |
-    NOT NULL
-    RETURNS NULL ON NULL INPUT
     VOLATILE
   sql: |
     SELECT
@@ -30,8 +28,6 @@
     - [data, VARIANT]
   return_type: VARIANT
   options: |
-    NOT NULL
-    RETURNS NULL ON NULL INPUT
     VOLATILE
   sql: |
     SELECT
@@ -49,8 +45,6 @@
     - [data, VARIANT]
   return_type: VARIANT
   options: |
-    NOT NULL
-    RETURNS NULL ON NULL INPUT
     VOLATILE
   sql: |
     SELECT
@@ -69,8 +63,6 @@
     - [secret_name, STRING]
   return_type: VARIANT
   options: |
-    NOT NULL
-    RETURNS NULL ON NULL INPUT
     VOLATILE
   sql: |
     SELECT
@@ -87,8 +79,6 @@
     - [url, STRING]
   return_type: VARIANT
   options: |
-    NOT NULL
-    RETURNS NULL ON NULL INPUT
     VOLATILE
   sql: |
     SELECT
@@ -106,8 +96,6 @@
     - [secret_name, STRING]
   return_type: VARIANT
   options: |
-    NOT NULL
-    RETURNS NULL ON NULL INPUT
     VOLATILE
   sql: |
     SELECT
@@ -128,8 +116,6 @@
     - [parameters, VARIANT]
   return_type: VARIANT
   options: |
-    NOT NULL
-    RETURNS NULL ON NULL INPUT
     VOLATILE
     COMMENT = $$Executes an JSON RPC call on a blockchain.$$
   sql: |
@@ -141,9 +127,8 @@
   func_type: EXTERNAL
   api_integration: '{{ var("API_INTEGRATION") }}'
   options: |
-    NOT NULL
-    RETURNS NULL ON NULL INPUT
     VOLATILE
+    RETURNS NULL ON NULL INPUT
     COMMENT = $$Returns a list of allowed domains.$$
   sql: allowed
 {% endmacro %}


### PR DESCRIPTION
This pull request refactors the options in macros/core/live.yaml.sql and adds support for null values in udf_api. The changes ensure that nulls are allowed in the udf_api function and remove the "RETURNS NULL ON NULL INPUT" option from the options section. This improves the flexibility and usability of the codebase.