### PR TITLE
update upload-artifact to v4

### DIFF
--- a/.github/workflows/dbt.yml
+++ b/.github/workflows/dbt.yml
@@ -51,7 +51,7 @@ jobs:
           ${{ inputs.command }}
       - name: Store logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: logs-${{ inputs.environment }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: |


### PR DESCRIPTION
- Updates `upload-artifact` to `v4` as `v3` is [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) as off `01/30/2025`

GHA [Error](https://github.com/FlipsideCrypto/livequery-models/actions/runs/13063573414/job/36451760872#step:1:36)