### PR TITLE
Stream 1175/reinstate deploy core

### DIFF
--- a/data/live__verified_api_endpoints.csv
+++ b/data/live__verified_api_endpoints.csv
@@ -1,0 +1,12 @@
+Project,Endpoint,Type,Documentation
+Snapshot,https://hub.snapshot.org/graphql,GraphQL,https://docs.snapshot.org/graphql-api
+Defillama,https://api.llama.fi/,REST,https://defillama.com/docs/api
+Defillama,https://yields.llama.fi/,REST,https://defillama.com/docs/api
+Defillama,https://stablecoins.llama.fi/,REST,https://defillama.com/docs/api
+Defillama,https://bridges.llama.fi/,REST,https://defillama.com/docs/api
+Defillama,https://coins.llama.fi/,REST,https://defillama.com/docs/api
+zkSync,https://api.zksync.io/api/v0.2/,REST,https://docs.zksync.io/apiv02-docs/
+DeepNFT Value,https://api.deepnftvalue.com/v1,REST,https://deepnftvalue.readme.io/reference/getting-started-with-deepnftvalue-api
+Zapper,https://api.zapper.fi/v2/,REST,https://api.zapper.fi/api/static/index.html#/Apps/AppsController_getApps
+Helius,https://api.helius.xyz,REST,https://docs.helius.xyz/introduction/why-helius
+Stargaze Name Service,https://rest.stargaze-apis.com,REST,https://github.com/public-awesome/names/blob/main/API.md

--- a/macros/livequery/manage_udfs.sql
+++ b/macros/livequery/manage_udfs.sql
@@ -161,7 +161,7 @@
         {%- else -%}
             {%- do log("Deploy core udfs: " ~ this.database ~ "." ~ this.schema, true) -%}
         {%- endif -%}
-        {%- do run_query(sql ~ apply_grants_by_schema(this.schema)) -%}
+        {%- do run_query(sql ~ livequery_models.apply_grants_by_schema(this.schema)) -%}
     {%- endif -%}
     SELECT '{{ model.schema }}' as schema_
 {%- endmacro -%}
@@ -185,7 +185,7 @@
         {%- else -%}
             {%- do log("Deploy partner udfs: " ~ this.database ~ "." ~ schema, true) -%}
         {%- endif -%}
-        {%- do run_query(sql ~ apply_grants_by_schema(schema)) -%}
+        {%- do run_query(sql ~ livequery_models.apply_grants_by_schema(schema)) -%}
     {%- endif -%}
     SELECT '{{ model.schema }}' as schema_
 {%- endmacro -%}
@@ -208,7 +208,7 @@
         {%- else -%}
             {%- do log("Deploy marketplace udfs: " ~ this.database ~ "." ~ schema, true) -%}
         {%- endif -%}
-        {%- do run_query(sql ~ apply_grants_by_schema(schema)) -%}
+        {%- do run_query(sql ~ livequery_models.apply_grants_by_schema(schema)) -%}
     {%- endif -%}
     SELECT '{{ model.schema }}' as schema_
 {%- endmacro -%}

--- a/macros/livequery/manage_udfs.sql
+++ b/macros/livequery/manage_udfs.sql
@@ -36,7 +36,7 @@
         func_type = none
     ) %}
     CREATE OR REPLACE {{ func_type }} FUNCTION {{ name_ }}(
-            {{- compile_signature(signature) }}
+            {{- livequery_models.compile_signature(signature) }}
     )
     COPY GRANTS
     RETURNS {{ return_type }}
@@ -45,7 +45,7 @@
     {% endif %}
     {%- if api_integration -%}
     api_integration = {{ api_integration }}
-    AS {{ construct_api_route(sql_) ~ ";" }}
+    AS {{ livequery_models.construct_api_route(sql_) ~ ";" }}
     {% else -%}
     AS
     $$
@@ -67,7 +67,7 @@
     {% set func_type = config ["func_type"] %}
 
     {% if not drop_ -%}
-        {{ create_sql_function(
+        {{ livequery_models.create_sql_function(
             name_ = name_,
             signature = signature,
             return_type = return_type,
@@ -113,7 +113,7 @@
     CREATE SCHEMA IF NOT EXISTS {{ schema }};
     {%-  set configs = fromyaml(config_func(blockchain, network)) if network else fromyaml(config_func(schema, blockchain)) -%}
     {%- for udf in configs -%}
-        {{- create_or_drop_function_from_config(udf, drop_=drop_) -}}
+        {{- livequery_models.create_or_drop_function_from_config(udf, drop_=drop_) -}}
     {%- endfor -%}
 {%- endmacro -%}
 
@@ -147,14 +147,14 @@
   {%- endfor -%}
 {%- endmacro -%}
 
-{% macro ephemeral_deploy_core(config) %}
+{% macro livequery_models.ephemeral_deploy_core(config) %}
 {#
     This macro is used to deploy functions using ephemeral models.
     It should only be used within an ephemeral model.
  #}
     {% if execute and (var("UPDATE_UDFS_AND_SPS") or var("DROP_UDFS_AND_SPS")) and model.unique_id in selected_resources %}
         {% set sql %}
-            {{- crud_udfs(config, this.schema, var("DROP_UDFS_AND_SPS")) -}}
+            {{- livequery_models.crud_udfs(config, this.schema, var("DROP_UDFS_AND_SPS")) -}}
         {%- endset -%}
         {%- if var("DROP_UDFS_AND_SPS") -%}
             {%- do log("Drop core udfs: " ~ this.database ~ "." ~ this.schema, true) -%}

--- a/macros/livequery/manage_udfs.sql
+++ b/macros/livequery/manage_udfs.sql
@@ -147,7 +147,7 @@
   {%- endfor -%}
 {%- endmacro -%}
 
-{% macro livequery_models.ephemeral_deploy_core(config) %}
+{% macro ephemeral_deploy_core(config) %}
 {#
     This macro is used to deploy functions using ephemeral models.
     It should only be used within an ephemeral model.
@@ -177,7 +177,7 @@
     {% if execute and (var("UPDATE_UDFS_AND_SPS") or var("DROP_UDFS_AND_SPS")) and model.unique_id in selected_resources %}
         {% set sql %}
             {% for config in configs %}
-                {{- crud_udfs_by_chain(config, blockchain, network, var("DROP_UDFS_AND_SPS")) -}}
+                {{- livequery_models.crud_udfs_by_chain(config, blockchain, network, var("DROP_UDFS_AND_SPS")) -}}
             {%- endfor -%}
         {%- endset -%}
         {%- if var("DROP_UDFS_AND_SPS") -%}

--- a/macros/utils/udf_utils/render.sql
+++ b/macros/utils/udf_utils/render.sql
@@ -1,0 +1,67 @@
+{% macro get_rendered_model(package_name, model_name, schema, blockchain, network) %}
+    {# 
+    This macro retrieves and renders a specified model from the graph.
+
+    Args:
+        package_name (str): The name of the package containing the model.
+        model_name (str): The name of the model to be rendered.
+        schema (str): The schema to be used.
+        blockchain (str): The blockchain to be used.
+        network (str): The network to be used.
+
+    Returns:
+        str: The rendered SQL of the specified model.
+    #}
+    {% if execute %}
+    {{ log("=== Starting get_rendered_model ===", info=True) }}
+    {# Use a list to store the node to avoid scope issues #}
+    {%- set nodes = [] -%}
+    {{ log("Looking for node: " ~ package_name ~ "." ~ model_name, info=True) }}
+    {%- for node in graph.nodes.values() -%}
+        {%- if node.package_name == package_name and node.name == model_name -%}
+            {{ log("Found target node: " ~ node.unique_id, info=True) }}
+            {%- do nodes.append(node) -%}
+        {%- endif -%}
+    {%- endfor -%}
+
+    {%- if nodes | length == 0 -%}
+        {{ log("No target node found!", info=True) }}
+        {{ return('') }}
+    {%- endif -%}
+
+    {%- set target_node = nodes[0] -%}
+    {{ log("Processing node: " ~ target_node.unique_id, info=True) }}
+    {{ log("Dependencies:\n\t\t" ~ (target_node.depends_on.nodes | pprint).replace("\n", "\n\t\t"), info=True) }}
+
+    {# First render all dependency CTEs #}
+    {%- set ctes = [] -%}
+    {%- for dep_id in target_node.depends_on.nodes -%}
+        {{ log("Processing dependency: " ~ dep_id, info=True) }}
+        {%- set dep_node = graph.nodes[dep_id] -%}
+
+        {%- set rendered_sql = render(dep_node.raw_code) | trim -%}
+
+        {%- if rendered_sql -%}
+            {%- set cte_sql -%}
+__dbt__cte__{{ dep_node.name }} AS (
+    {{ rendered_sql }}
+)
+            {%- endset -%}
+            {%- do ctes.append(cte_sql) -%}
+        {%- endif -%}
+    {%- endfor -%}
+
+    {{ log("Number of CTEs generated: " ~ ctes | length, info=True) }}
+
+    {# Combine CTEs with main query #}
+    {%- set final_sql -%}
+WITH {{ ctes | join(',\n\n') }}
+
+{{ render(target_node.raw_code) }}
+    {%- endset -%}
+
+    {{ log("=== End get_rendered_model ===\n\n" , info=True) }}
+
+    {{ return(final_sql) }}
+    {% endif %}
+{% endmacro %}

--- a/models/deploy/core/_live.sql
+++ b/models/deploy/core/_live.sql
@@ -1,0 +1,2 @@
+{% set config = config_core__live %}
+{{ ephemeral_deploy_core(config) }}

--- a/models/deploy/core/_utils.sql
+++ b/models/deploy/core/_utils.sql
@@ -1,0 +1,2 @@
+{% set config = config_core__utils %}
+{{ ephemeral_deploy_core(config) }}

--- a/models/deploy/core/_utils.yml
+++ b/models/deploy/core/_utils.yml
@@ -1,0 +1,11 @@
+version: 2
+models:
+  - name: _utils
+    columns:
+      - name: udf_introspect
+        tests:
+          - test_udf:
+              name: test___utils_udf_introspect
+              args: "'hello'"
+              assertions:
+                - result = 'hello'

--- a/models/deploy/core/live.sql
+++ b/models/deploy/core/live.sql
@@ -1,0 +1,5 @@
+-- depends_on: {{ ref('_utils') }}
+-- depends_on: {{ ref('utils') }}
+-- depends_on: {{ ref('_live') }}
+{% set config = config_core_live %}
+{{ ephemeral_deploy_core(config) }}

--- a/models/deploy/core/live.yml
+++ b/models/deploy/core/live.yml
@@ -1,0 +1,27 @@
+version: 2
+models:
+  - name: live
+    columns:
+      - name: udf_api
+        tests:
+          - test_udf:
+              name: test__live_udf_api_post_data_object
+              args: |
+                'https://httpbin.org/post', {'foo': 'bar'}
+              assertions:
+                - result:data.json is not null
+                - result:data.json = OBJECT_CONSTRUCT('foo', 'bar')
+          - test_udf:
+              name: test__live_udf_api_post_data_array
+              args: |
+                'https://httpbin.org/post', ['foo', 'bar']
+              assertions:
+                - result:data.json is not null
+                - result:data.json = ARRAY_CONSTRUCT('foo', 'bar')
+          - test_udf:
+              name: test__live_udf_api_post_data_string
+              args: |
+                'https://httpbin.org/post', 'foo'::VARIANT
+              assertions:
+                - result:data.json is not null
+                - result:data.json = 'foo'

--- a/models/deploy/core/secrets.sql
+++ b/models/deploy/core/secrets.sql
@@ -1,0 +1,4 @@
+-- depends_on: {{ ref('_utils') }}
+-- depends_on: {{ ref('live') }}
+{% set config = config_core_secrets %}
+{{ ephemeral_deploy_core(config) }}

--- a/models/deploy/core/utils.sql
+++ b/models/deploy/core/utils.sql
@@ -1,0 +1,3 @@
+ -- depends_on: {{ ref('_utils') }}
+{% set config = config_core_utils %}
+{{ ephemeral_deploy_core(config) }}

--- a/models/deploy/core/utils.yml
+++ b/models/deploy/core/utils.yml
@@ -1,0 +1,269 @@
+version: 2
+models:
+  - name: utils
+    columns:
+      - name: udf_json_rpc_call
+        tests:
+          - test_udf:
+              name: test__utils_udf_json_rpc_call
+              args: "'foo', [], 1"
+              assertions:
+                - >
+                  result = {
+                    'jsonrpc': '2.0',
+                    'method': 'foo',
+                    'params': [],
+                    'id': '1'
+                  }
+      - name: udf_urlencode
+        tests:
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_true_1
+              args: >
+                {'a':'b'}, TRUE
+              assertions:
+                - result = 'a=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_true_2
+              args: >
+                {'a':'a', 'b':'b'}, TRUE
+              assertions:
+                - result = 'a=a&b=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_true_space
+              args: >
+                  {'space': 'abc 123'}, TRUE
+              assertions:
+                - result = 'space=abc+123'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_true_special
+              args: >
+                  {'special!': ' !@#$,+"'}, TRUE
+              assertions:
+                - result = 'special%21=+%21%40%23%24%2C%2B%22'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_true_array
+              args: >
+                  {'array': [0, 1, 2]}, TRUE
+              assertions:
+                - result = 'array=0&array=1&array=2'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_false_1
+              args: >
+                {'a':'b'}, FALSE
+              assertions:
+                - result = 'a=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_false_2
+              args: >
+                {'a':'b', 'b':'b'}, FALSE
+              assertions:
+                - result = 'a=b&b=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_false_space
+              args: >
+                  {'space': 'abc 123'}, FALSE
+              assertions:
+                - result = 'space=abc+123'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_false_special
+              args: >
+                  {'special!': ' !@#$,+"'}, FALSE
+              assertions:
+                - result = 'special%21=+%21%40%23%24%2C%2B%22'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_false_array
+              args: >
+                  {'array': [0, 1, 2]}, FALSE
+              assertions:
+                - result = 'array=%5B0%2C+1%2C+2%5D'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_1
+              args: >
+                {'a':'b'}
+              assertions:
+                - result = 'a=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_2
+              args: >
+                {'a':'b', 'b':'b'}
+              assertions:
+                - result = 'a=b&b=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_space
+              args: >
+                  {'space': 'abc 123'}
+              assertions:
+                - result = 'space=abc+123'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_special
+              args: >
+                  {'special!': ' !@#$,+"'}
+              assertions:
+                - result = 'special%21=+%21%40%23%24%2C%2B%22'
+          - test_udf:
+              name: test__utils_udf_urlencode_dict_array
+              args: >
+                  {'array': [0, 1, 2]}
+              assertions:
+                - result = 'array=%5B0%2C+1%2C+2%5D'
+          # write tests but use arrays of arrays instead of dictionaries
+          - test_udf:
+              name: test__utils_udf_urlencode_array_true_1
+              args: >
+                [['a', 'b']], TRUE
+              assertions:
+                - result = 'a=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_true_2
+              args: >
+                [['a', 'a'], ['b', 'b']], TRUE
+              assertions:
+                - result = 'a=a&b=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_true_space
+              args: >
+                  [['space', 'abc 123']], TRUE
+              assertions:
+                - result = 'space=abc+123'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_true_special
+              args: >
+                  [['special!', ' !@#$,+"']], TRUE
+              assertions:
+                - result = 'special%21=+%21%40%23%24%2C%2B%22'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_true_array
+              args: >
+                  [['array', [0, 1, 2]]], TRUE
+              assertions:
+                - result = 'array=0&array=1&array=2'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_false_1
+              args: >
+                [['a', 'b']], FALSE
+              assertions:
+                - result = 'a=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_false_2
+              args: >
+                [['a', 'a'], ['b', 'b']], FALSE
+              assertions:
+                - result = 'a=a&b=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_false_space
+              args: >
+                  [['space', 'abc 123']], FALSE
+              assertions:
+                - result = 'space=abc+123'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_false_special
+              args: >
+                  [['special!', ' !@#$,+"']], FALSE
+              assertions:
+                - result = 'special%21=+%21%40%23%24%2C%2B%22'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_false_array
+              args: >
+                  [['array', [0, 1, 2]]], FALSE
+              assertions:
+                - result = 'array=%5B0%2C+1%2C+2%5D'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_1
+              args: >
+                [['a', 'b']]
+              assertions:
+                - result = 'a=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_2
+              args: >
+                [['a', 'a'], ['b', 'b']]
+              assertions:
+                - result = 'a=a&b=b'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_space
+              args: >
+                  [['space', 'abc 123']]
+              assertions:
+                - result = 'space=abc+123'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_special
+              args: >
+                  [['special!', ' !@#$,+"']]
+              assertions:
+                - result = 'special%21=+%21%40%23%24%2C%2B%22'
+          - test_udf:
+              name: test__utils_udf_urlencode_array_array
+              args: >
+                  [['array', [0, 1, 2]]]
+              assertions:
+                - result = 'array=%5B0%2C+1%2C+2%5D'
+      - name: udf_int_to_binary
+        tests:
+          - test_udf:
+              name: test__utils_udf_int_to_binary
+              args: 123456789
+              assertions: 
+              - result = '111010110111100110100010101'
+      - name: udf_int_to_binary
+        tests:
+          - test_udf:
+              name: test__utils_udf_int_to_binary_large_number
+              args: "'123456789123456789123456789123456789123456789'"
+              assertions: 
+              - result = '101100010010011011011100101001111010001001110011010111111101111101010111011001001101000001111110001010100001011011010000100000001000101111100010101'
+      - name: udf_binary_to_int
+        tests:
+          - test_udf:
+              name: test__utils_udf_binary_to_int
+              args: '111010110111100110100010101'
+              assertions: 
+              - result = '123456789'
+      - name: udf_binary_to_int
+        tests:
+          - test_udf:
+              name: test__utils_udf_binary_to_int_large_number
+              args: "'110110110100110110100101110101100110100000101111100010101'"
+              assertions: 
+              - result = '123456789123456789'
+      - name: udf_evm_decode_log
+        tests:
+          - test_udf:
+              name: test__utils_udf_evm_decode_log
+              args: >
+                {
+                  'anonymous': false,
+                  'inputs': [
+                    {
+                      'indexed': false,
+                      'name': 'nonce',
+                      'type': 'uint256'
+                    }
+                  ],
+                  'name': 'NonceChanged',
+                  'type': 'event'
+                }::variant,
+                {
+                  'address': '0x55032650b14df07b85bf18a3a3ec8e0af2e028d5',
+                  'data': '0x000000000000000000000000000000000000000000000000000000000000279c',
+                  'topics': [
+                    '0x7220970e1f1f12864ecccd8942690a837c7a8dd45d158cb891eb45a8a69134aa'
+                  ]
+                }::variant
+              assertions:
+                - >
+                  result = [
+                    {
+                      'address': '0x55032650b14df07b85bF18A3a3eC8E0Af2e028d5',
+                      'data': [
+                        {
+                          'decoded': true,
+                          'name': 'nonce',
+                          'type': 'uint256',
+                          'value': 10140
+                        }
+                      ],
+                      'decoded': true,
+                      'name': 'NonceChanged'
+                    }
+                  ]

--- a/models/deploy/evm/arbitrum_nova__mainnet.sql
+++ b/models/deploy/evm/arbitrum_nova__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/arbitrum_one__goerli.sql
+++ b/models/deploy/evm/arbitrum_one__goerli.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/arbitrum_one__mainnet.sql
+++ b/models/deploy/evm/arbitrum_one__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/avalanche_c__mainnet.sql
+++ b/models/deploy/evm/avalanche_c__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/avalanche_c__testnet.sql
+++ b/models/deploy/evm/avalanche_c__testnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/base__goerli.sql
+++ b/models/deploy/evm/base__goerli.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/base__mainnet.sql
+++ b/models/deploy/evm/base__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/bsc__mainnet.sql
+++ b/models/deploy/evm/bsc__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/bsc__testnet.sql
+++ b/models/deploy/evm/bsc__testnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/celo__mainnet.sql
+++ b/models/deploy/evm/celo__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/ethereum__goerli.sql
+++ b/models/deploy/evm/ethereum__goerli.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/ethereum__mainnet.sql
+++ b/models/deploy/evm/ethereum__mainnet.sql
@@ -3,8 +3,8 @@
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
 -- depends_on: {{ ref('_eth__logs') }}
 -- depends_on: {{ ref('_eth__decoded_logs') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions,

--- a/models/deploy/evm/ethereum__sepolia.sql
+++ b/models/deploy/evm/ethereum__sepolia.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/fantom__mainnet.sql
+++ b/models/deploy/evm/fantom__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/gnosis__mainnet.sql
+++ b/models/deploy/evm/gnosis__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/harmony__mainnet.sql
+++ b/models/deploy/evm/harmony__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/harmony__testnet.sql
+++ b/models/deploy/evm/harmony__testnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/optimism__goerli.sql
+++ b/models/deploy/evm/optimism__goerli.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/optimism__mainnet.sql
+++ b/models/deploy/evm/optimism__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/polygon__mainnet.sql
+++ b/models/deploy/evm/polygon__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/polygon__testnet.sql
+++ b/models/deploy/evm/polygon__testnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/polygon_zkevm__mainnet.sql
+++ b/models/deploy/evm/polygon_zkevm__mainnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/evm/polygon_zkevm__testnet.sql
+++ b/models/deploy/evm/polygon_zkevm__testnet.sql
@@ -1,8 +1,8 @@
 -- depends_on: {{ ref('_evm__contracts_map') }}
 -- depends_on: {{ ref('_evm__abi_map') }}
 -- depends_on: {{ ref('_evm__native_symbol_map') }}
-
-
+-- depends_on: {{ ref('live') }}
+-- depends_on: {{ ref('utils') }}
 {%- set configs = [
     config_evm_rpc_primitives,
     config_evm_high_level_abstractions

--- a/models/deploy/marketplace/alchemy/alchemy_nfts__alchemy_utils.sql
+++ b/models/deploy/marketplace/alchemy/alchemy_nfts__alchemy_utils.sql
@@ -4,3 +4,4 @@
     ] -%}
 {{- ephemeral_deploy_marketplace(configs) -}}
 -- depends_on: {{ ref('alchemy_utils__alchemy_utils') }}
+-- depends_on: {{ ref('live') }}

--- a/models/deploy/marketplace/alchemy/alchemy_tokens__alchemy_utils.sql
+++ b/models/deploy/marketplace/alchemy/alchemy_tokens__alchemy_utils.sql
@@ -4,3 +4,4 @@
     ] -%}
 {{- ephemeral_deploy_marketplace(configs) -}}
 -- depends_on: {{ ref('alchemy_utils__alchemy_utils') }}
+-- depends_on: {{ ref('live') }}

--- a/models/deploy/marketplace/alchemy/alchemy_transfers__alchemy_utils.sql
+++ b/models/deploy/marketplace/alchemy/alchemy_transfers__alchemy_utils.sql
@@ -4,3 +4,4 @@
     ] -%}
 {{- ephemeral_deploy_marketplace(configs) -}}
 -- depends_on: {{ ref('alchemy_utils__alchemy_utils') }}
+-- depends_on: {{ ref('live') }}

--- a/models/deploy/marketplace/alchemy/alchemy_utils__alchemy_utils.sql
+++ b/models/deploy/marketplace/alchemy/alchemy_utils__alchemy_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_alchemy_utils_udfs,
     ] -%}

--- a/models/deploy/marketplace/allday/allday__.sql
+++ b/models/deploy/marketplace/allday/allday__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_allday_udfs,
     ] -%}

--- a/models/deploy/marketplace/apilayer/apilayer__.sql
+++ b/models/deploy/marketplace/apilayer/apilayer__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_apilayer_udfs,
     ] -%}

--- a/models/deploy/marketplace/bitquery/bitquery__.sql
+++ b/models/deploy/marketplace/bitquery/bitquery__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_bitquery_udfs
     ] -%}

--- a/models/deploy/marketplace/blockpour/blockpour_utils__.sql
+++ b/models/deploy/marketplace/blockpour/blockpour_utils__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_blockpour_utils_udfs,
     ] -%}

--- a/models/deploy/marketplace/chainbase/chainbase_utils__.sql
+++ b/models/deploy/marketplace/chainbase/chainbase_utils__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_chainbase_utils_udfs,
     ] -%}

--- a/models/deploy/marketplace/claude/claude__.sql
+++ b/models/deploy/marketplace/claude/claude__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_claude_messages_udfs,
     config_claude_models_udfs,

--- a/models/deploy/marketplace/claude/claude_utils__claude_utils.sql
+++ b/models/deploy/marketplace/claude/claude_utils__claude_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_claude_utils_udfs,
     ] -%}

--- a/models/deploy/marketplace/cmc/cmc__.sql
+++ b/models/deploy/marketplace/cmc/cmc__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_cmc_udfs,
     ] -%}

--- a/models/deploy/marketplace/coingecko/coingecko__.sql
+++ b/models/deploy/marketplace/coingecko/coingecko__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_coingecko_udfs,
     ] -%}

--- a/models/deploy/marketplace/covalent/covalent__.sql
+++ b/models/deploy/marketplace/covalent/covalent__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_covalent_udfs,
     ] -%}

--- a/models/deploy/marketplace/credmark/credmark_utils__.sql
+++ b/models/deploy/marketplace/credmark/credmark_utils__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_credmark_utils_udfs,
     ] -%}

--- a/models/deploy/marketplace/dapplooker/dapplooker__.sql
+++ b/models/deploy/marketplace/dapplooker/dapplooker__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_dapplooker_udfs
     ] -%}

--- a/models/deploy/marketplace/dappradar/dappradar__.sql
+++ b/models/deploy/marketplace/dappradar/dappradar__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_dappradar_udfs,
     ] -%}

--- a/models/deploy/marketplace/deepnftvalue/deepnftvalue__.sql
+++ b/models/deploy/marketplace/deepnftvalue/deepnftvalue__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_deepnftvalue_udfs,
     ] -%}

--- a/models/deploy/marketplace/defillama/defillama__.sql
+++ b/models/deploy/marketplace/defillama/defillama__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_defillama_udfs,
     ] -%}

--- a/models/deploy/marketplace/espn/espn__.sql
+++ b/models/deploy/marketplace/espn/espn__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_espn_udfs,
     ] -%}

--- a/models/deploy/marketplace/footprint/footprint_utils__footprint_utils.sql
+++ b/models/deploy/marketplace/footprint/footprint_utils__footprint_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_footprint_utils_udfs,
     ] -%}

--- a/models/deploy/marketplace/fred/fred__.sql
+++ b/models/deploy/marketplace/fred/fred__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_fred_udfs,
     ] -%}

--- a/models/deploy/marketplace/github/github_actions__github_utils.sql
+++ b/models/deploy/marketplace/github/github_actions__github_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 -- depends_on: {{ ref('github_utils__github_utils') }}
 {%- set configs = [
     config_github_actions_udfs,

--- a/models/deploy/marketplace/github/github_utils__github_utils.sql
+++ b/models/deploy/marketplace/github/github_utils__github_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_github_utils_udfs,
     ] -%}

--- a/models/deploy/marketplace/helius/helius_apis__helius_utils.sql
+++ b/models/deploy/marketplace/helius/helius_apis__helius_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_helius_apis_udfs,
     ] -%}

--- a/models/deploy/marketplace/helius/helius_das__helius_utils.sql
+++ b/models/deploy/marketplace/helius/helius_das__helius_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_helius_das_udfs,
     ] -%}

--- a/models/deploy/marketplace/helius/helius_utils__helius_utils.sql
+++ b/models/deploy/marketplace/helius/helius_utils__helius_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_helius_utils_udfs,
     ] -%}

--- a/models/deploy/marketplace/nftscan/nftscan__.sql
+++ b/models/deploy/marketplace/nftscan/nftscan__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_nftscan_udfs,
     ] -%}

--- a/models/deploy/marketplace/opensea/opensea__.sql
+++ b/models/deploy/marketplace/opensea/opensea__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_opensea_udfs,
     ] -%}

--- a/models/deploy/marketplace/playgrounds/playgrounds__.sql
+++ b/models/deploy/marketplace/playgrounds/playgrounds__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_playgrounds_udfs,
     ] -%}

--- a/models/deploy/marketplace/quicknode/quicknode_ethereum_nfts__quicknode_utils.sql
+++ b/models/deploy/marketplace/quicknode/quicknode_ethereum_nfts__quicknode_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_quicknode_ethereum_nfts_udfs,
     ] -%}

--- a/models/deploy/marketplace/quicknode/quicknode_ethereum_tokens__quicknode_utils.sql
+++ b/models/deploy/marketplace/quicknode/quicknode_ethereum_tokens__quicknode_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_quicknode_ethereum_tokens_udfs,
     ] -%}

--- a/models/deploy/marketplace/quicknode/quicknode_polygon_nfts__quicknode_utils.sql
+++ b/models/deploy/marketplace/quicknode/quicknode_polygon_nfts__quicknode_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_quicknode_polygon_nfts_udfs,
     ] -%}

--- a/models/deploy/marketplace/quicknode/quicknode_polygon_tokens__quicknode_utils.sql
+++ b/models/deploy/marketplace/quicknode/quicknode_polygon_tokens__quicknode_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_quicknode_polygon_tokens_udfs,
     ] -%}

--- a/models/deploy/marketplace/quicknode/quicknode_solana_nfts__quicknode_utils.sql
+++ b/models/deploy/marketplace/quicknode/quicknode_solana_nfts__quicknode_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_quicknode_solana_nfts_udfs,
     ] -%}

--- a/models/deploy/marketplace/quicknode/quicknode_utils__quicknode_utils.sql
+++ b/models/deploy/marketplace/quicknode/quicknode_utils__quicknode_utils.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_quicknode_utils_udfs,
     ] -%}

--- a/models/deploy/marketplace/reservoir/reservoir__.sql
+++ b/models/deploy/marketplace/reservoir/reservoir__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_reservoir_udfs,
     ] -%}

--- a/models/deploy/marketplace/snapshot/snapshot__.sql
+++ b/models/deploy/marketplace/snapshot/snapshot__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_snapshot_udfs,
     ] -%}

--- a/models/deploy/marketplace/solscan/solscan__.sql
+++ b/models/deploy/marketplace/solscan/solscan__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_solscan_udfs,
     ] -%}

--- a/models/deploy/marketplace/stakingrewards/stakingrewards__.sql
+++ b/models/deploy/marketplace/stakingrewards/stakingrewards__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_stakingrewards_udfs,
     ] -%}

--- a/models/deploy/marketplace/strangelove/strangelove__.sql
+++ b/models/deploy/marketplace/strangelove/strangelove__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_strangelove_udfs
     ] -%}

--- a/models/deploy/marketplace/subquery/subquery__.sql
+++ b/models/deploy/marketplace/subquery/subquery__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_subquery_udfs
     ] -%}

--- a/models/deploy/marketplace/topshot/topshot__.sql
+++ b/models/deploy/marketplace/topshot/topshot__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_topshot_udfs,
     ] -%}

--- a/models/deploy/marketplace/transpose/transpose__.sql
+++ b/models/deploy/marketplace/transpose/transpose__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_transpose_udfs,
     ] -%}

--- a/models/deploy/marketplace/zapper/zapper__.sql
+++ b/models/deploy/marketplace/zapper/zapper__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_zapper_udfs,
     ] -%}

--- a/models/deploy/marketplace/zettablock/zettablock__.sql
+++ b/models/deploy/marketplace/zettablock/zettablock__.sql
@@ -1,4 +1,4 @@
-
+-- depends_on: {{ ref('live') }}
 {%- set configs = [
     config_zettablock_udfs,
     ] -%}

--- a/models/live__allow_list.sql
+++ b/models/live__allow_list.sql
@@ -1,0 +1,11 @@
+-- depends_on: {{ ref('live') }}
+{{ config(
+    materialized = 'view',
+    grants = {'+select': fromyaml(var('ROLES'))}
+) }}
+SELECT '*.' || t.value AS allowed_domains
+FROM table(flatten(input => {{ this.database }}.live.udf_allow_list())) AS t
+ORDER BY
+    split_part(allowed_domains, '.', -1),
+    split_part(allowed_domains, '.', -2),
+    split_part(allowed_domains, '.', -3)

--- a/packages.yml
+++ b/packages.yml
@@ -3,5 +3,4 @@ packages:
     version: [">=0.8.0", "<0.9.0"]
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
-  - git: https://github.com/FlipsideCrypto/livequery-base.git
-    revision: v1.0.1
+ 

--- a/tests/generic/test_udf.sql
+++ b/tests/generic/test_udf.sql
@@ -1,12 +1,39 @@
 {% test test_udf(model, column_name, args, assertions) %}
     {#
         This is a generic test for UDFs.
-        The udfs are deployed using ephemeral models, so we need to
-        use the ephemeral model name to get the udf name.
+        The udfs are deployed using ephemeral models, as of dbt-core > 1.8
+        we need to use `this.identifier` to extract the schema from for base_test_udf().
      #}
-    {%- set schema = model | replace("__dbt__cte__", "") -%}
-    {%- set schema = schema.split("__") | first -%}
-    {%- set udf = schema ~ "." ~ column_name -%}
+    
+    {% set schema = none %}
+    
+    {% if execute %}
+        {# Extract schema based on standard pattern `test__<schema_name>_<test_name> #}
+        {% set test_identifier = this.identifier %}
+        
+        {% if test_identifier.startswith('test_') %}
+            {% set test_identifier = test_identifier[5:] %}
+        {% endif %}
+        
+        {# Handle schemas with underscore prefix #}
+        {% if test_identifier.startswith('_') %}
+            {# For identifiers like _utils_<test_name> #}
+            {% set parts = test_identifier.split('_') %}
+            {% if parts | length > 2 %}
+                {% set schema = '_' ~ parts[1] %}
+            {% else %}
+                {% set schema = parts[0] %}
+            {% endif %}
+        {% else %}
+            {# For identifiers without underscore prefix #}
+            {% set parts = test_identifier.split('_') %}
+            {% if parts | length > 0 %}
+                {% set schema = parts[0] %}
+            {% endif %}
+        {% endif %}
+    {% endif %}
+    
+    {% set udf = schema ~ "." ~ column_name %}
 
     {{ base_test_udf(model, udf, args, assertions) }}
 {% endtest %}


### PR DESCRIPTION
Each `live table UDTF` will be created in for that project's `<chain>-models` repo, as such we no longer have a circular dependency issue and will deprecate (livequery-base)[https://github.com/FlipsideCrypto/livequery-base]. 

This PR moves the ephemeral `models/deploy/core` UDF definitions back to `livequery-models` and adds the updates to `test_udf` as applied [here](https://github.com/FlipsideCrypto/livequery-base/pull/6) and namespace scopes macros used in dbt packges as applied [here](https://github.com/FlipsideCrypto/livequery-base/pull/8). 

- Removes `livequery-base v1.0.1` from `packages.yml` 
- Adds logic to extract schema from this.identifier due to behaviour change for ephemeral model test in udf_test test macro
- Adds `test__` prefix to all `udf_test` names in deploy/core/utils.yml
- Adds `get_rendered_model()`