### PR TITLE
[STREAM-1205] Add additional UDF tests for live API endpoints in live.yml

### DIFF
--- a/models/deploy/core/live.yml
+++ b/models/deploy/core/live.yml
@@ -25,3 +25,95 @@ models:
               assertions:
                 - result:data.json is not null
                 - result:data.json = 'foo'
+          - test_udf:
+              name: test__live_udf_api_get_method
+              args: |
+                'https://httpbin.org/get'
+              assertions:
+                - result:status_code = 200
+                - result:data.url = 'https://httpbin.org/get'
+          - test_udf:
+              name: test__live_udf_api_get_with_params
+              args: |
+                'GET', 'https://httpbin.org/get', {'Content-Type': 'application/json'}, {'param1': 'value1', 'param2': 'value2'}
+              assertions:
+                - result:status_code = 200
+                - result:data.args is not null
+                - result:data.args:param1 = 'value1'
+                - result:data.args:param2 = 'value2'
+          - test_udf:
+              name: test__live_udf_api_post_batch_jsonrpc
+              args: |
+                'https://httpbin.org/post', {
+                  'jsonrpc': '2.0',
+                  'id': 1,
+                  'method': 'batch',
+                  'params': [
+                    {'id': 1, 'method': 'method1', 'params': {'param1': 'value1'}},
+                    {'id': 2, 'method': 'method2', 'params': {'param2': 'value2'}}
+                  ]
+                }
+              assertions:
+                - result:status_code = 200
+                - result:data.json:jsonrpc = '2.0'
+                - result:data.json:id = 1
+                - result:data.json:method = 'batch'
+                - result:data.json:params is not null
+                - result:data.json:params[0]:id = 1
+                - result:data.json:params[1]:id = 2
+          - test_udf:
+              name: test__live_udf_api_post_jsonrpc_solana
+              args: |
+                'POST',
+                'https://api.mainnet-beta.solana.com',
+                {'Content-Type': 'application/json'},
+                {
+                  'jsonrpc': '2.0',
+                  'id': 1,
+                  'method': 'getVersion'
+                },
+                ''
+              assertions:
+                - result:status_code = 200
+                - result:data.jsonrpc = '2.0'
+                - result:data.id = 1
+                - result:data.result is not null
+          - test_udf:
+              name: test__live_udf_api_post_jsonrpc_solana_batch
+              args: |
+                'POST',
+                'https://api.mainnet-beta.solana.com',
+                {'Content-Type': 'application/json'},
+                [
+                  {'jsonrpc': '2.0', 'id': 1, 'method': 'getVersion'},
+                  {'jsonrpc': '2.0', 'id': 2, 'method': 'getVersion'}
+                ],
+                ''
+              assertions:
+                - result:status_code = 200
+                - result:data[0]:jsonrpc = '2.0'
+                - result:data[0]:id = 1
+                - result:data[0]:result is not null
+                - result:data[1]:jsonrpc = '2.0'
+                - result:data[1]:id = 2
+                - result:data[1]:result is not null
+
+          - test_udf:
+              name: test__live_udf_api_post_jsonrpc_ethereum_batch
+              args: |
+                'POST',
+                'https://ethereum-rpc.publicnode.com',
+                {'Content-Type': 'application/json'},
+                [
+                  {'jsonrpc': '2.0', 'id': 1, 'method': 'eth_blockNumber', 'params': []},
+                  {'jsonrpc': '2.0', 'id': 2, 'method': 'eth_chainId', 'params': []}
+                ],
+                ''
+              assertions:
+                - result:status_code = 200
+                - result:data[0]:jsonrpc = '2.0'
+                - result:data[0]:id = 1
+                - result:data[0]:result is not null
+                - result:data[1]:jsonrpc = '2.0'
+                - result:data[1]:id = 2
+                - result:data[1]:result = '0x1'


### PR DESCRIPTION
- Introduced multiple test cases for GET and POST methods, including batch JSON-RPC requests for Solana and Ethereum.
- Ensured assertions validate response status codes and data structure integrity.
- Enhanced coverage for API interactions to improve reliability and robustness of the deployment core.

AS-IS
1. Only test the POST request

TO-BE
1. Batch POST
   - httpbin
   - solana public rpc
   - ethereum public rpc
2. GET method

The purpose of adding more test cases here is to be able run dbt test with the udf_api version in the chain schema and validate all requests are successful handle thru streamline runtime. This test should be included in the integration test in each dbt repo so that we can ensure the apis are functioning during an update.

In the future, we can keep updating/adding the tests for not just `udf_api` but on our bulk api endpoints as well to quickly verify no breaking changes happens during our minor/major updates

### Tests
```
➜  dbt test --select live
04:26:51  Running with dbt=1.7.19
04:26:51  Registered adapter: snowflake=1.7.5
04:26:51  Unable to do partial parsing because change detected to override macro. Starting full parse.
04:26:54  Found 80 models, 5 analyses, 1 seed, 2 operations, 147 tests, 5 sources, 0 exposures, 0 metrics, 957 macros, 0 groups, 0 semantic models
04:26:54  
04:26:59  
04:26:59  Running 1 on-run-start hook
04:26:59  1 of 1 START hook: livequery_models.on-run-start.0 ............................. [RUN]
04:26:59  1 of 1 OK hook: livequery_models.on-run-start.0 ................................ [OK in 0.00s]
04:26:59  
04:26:59  Concurrency: 24 threads (target='dev')
04:26:59  
04:26:59  1 of 9 START test test__live_udf_api_get_method ................................ [RUN]
04:26:59  2 of 9 START test test__live_udf_api_get_with_params ........................... [RUN]
04:26:59  3 of 9 START test test__live_udf_api_post_batch_jsonrpc ........................ [RUN]
04:26:59  4 of 9 START test test__live_udf_api_post_data_array ........................... [RUN]
04:26:59  5 of 9 START test test__live_udf_api_post_data_object .......................... [RUN]
04:26:59  6 of 9 START test test__live_udf_api_post_data_string .......................... [RUN]
04:26:59  7 of 9 START test test__live_udf_api_post_jsonrpc_ethereum_batch ............... [RUN]
04:26:59  8 of 9 START test test__live_udf_api_post_jsonrpc_solana ....................... [RUN]
04:26:59  9 of 9 START test test__live_udf_api_post_jsonrpc_solana_batch ................. [RUN]
04:27:08  3 of 9 PASS test__live_udf_api_post_batch_jsonrpc .............................. [PASS in 8.73s]
04:27:08  1 of 9 PASS test__live_udf_api_get_method ...................................... [PASS in 8.74s]
04:27:08  4 of 9 PASS test__live_udf_api_post_data_array ................................. [PASS in 8.74s]
04:27:08  8 of 9 PASS test__live_udf_api_post_jsonrpc_solana ............................. [PASS in 8.76s]
04:27:08  5 of 9 PASS test__live_udf_api_post_data_object ................................ [PASS in 8.76s]
04:27:08  9 of 9 PASS test__live_udf_api_post_jsonrpc_solana_batch ....................... [PASS in 8.76s]
04:27:08  7 of 9 PASS test__live_udf_api_post_jsonrpc_ethereum_batch ..................... [PASS in 8.78s]
04:27:08  2 of 9 PASS test__live_udf_api_get_with_params ................................. [PASS in 8.89s]
04:27:08  6 of 9 PASS test__live_udf_api_post_data_string ................................ [PASS in 9.13s]
04:27:08  
04:27:08  Running 1 on-run-end hook
04:27:08  1 of 1 START hook: livequery_models.on-run-end.0 ............................... [RUN]
04:27:08  1 of 1 OK hook: livequery_models.on-run-end.0 .................................. [OK in 0.00s]
04:27:08  
04:27:08  
04:27:08  Finished running 9 tests, 2 hooks in 0 hours 0 minutes and 14.50 seconds (14.50s).
04:27:08  
04:27:08  Completed successfully
04:27:08  
04:27:08  Done. PASS=9 WARN=0 ERROR=0 SKIP=0 TOTAL=9
```