### PR TITLE
add udf_api_batched

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,6 @@ deploy_core: rm_logs
 	dbt run --select livequery_models.deploy.core._live \
 	--vars '{UPDATE_UDFS_AND_SPS: true}' \
 	--profiles-dir ~/.dbt \
-	--profile near \
+	--profile livequery \
 	--target dev
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SHELL := /bin/bash
+
+dbt-console: 
+	docker-compose run dbt_console
+
+.PHONY: dbt-console
+
+rm_logs:
+	@if [ -d logs ]; then \
+		rm -r logs 2>/dev/null || echo "Warning: Could not remove logs directory"; \
+	else \
+		echo "Logs directory does not exist"; \
+	fi
+
+
+deploy_core: rm_logs
+	dbt run --select livequery_models.deploy.core._live \
+	--vars '{UPDATE_UDFS_AND_SPS: true}' \
+	--profiles-dir ~/.dbt \
+	--profile near \
+	--target dev
+

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,14 @@ rm_logs:
 
 
 deploy_core: rm_logs
-	dbt run --select livequery_models.deploy.core._live \
+	dbt run --select livequery_models.deploy.core.live \
 	--vars '{UPDATE_UDFS_AND_SPS: true}' \
+	--profiles-dir ~/.dbt \
+	--profile livequery \
+	--target dev
+
+test_core: rm_logs
+	dbt test --select live \
 	--profiles-dir ~/.dbt \
 	--profile livequery \
 	--target dev

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -67,6 +67,7 @@ vars:
   API_INTEGRATION: '{{ var("config")[target.name]["API_INTEGRATION"] }}'
   EXTERNAL_FUNCTION_URI: '{{ var("config")[target.name]["EXTERNAL_FUNCTION_URI"] }}'
   ROLES: '{{ var("config")[target.name]["ROLES"] }}'
+  MAX_BATCH_ROWS: '{{ var("config")[target.name]["MAX_BATCH_ROWS"] }}'
 
   config:
   # The keys correspond to dbt profiles and are case sensitive
@@ -75,6 +76,7 @@ vars:
       EXTERNAL_FUNCTION_URI: u5z0tu43sc.execute-api.us-east-1.amazonaws.com/stg/
       ROLES:
         - INTERNAL_DEV
+      MAX_BATCH_ROWS: 10
     prod:
       API_INTEGRATION: AWS_LIVE_QUERY
       EXTERNAL_FUNCTION_URI: bqco8lkjsb.execute-api.us-east-1.amazonaws.com/prod/
@@ -83,8 +85,10 @@ vars:
         - VELOCITY_ETHEREUM
         - INTERNAL_DEV
         - BI_ANALYTICS_READER
+      MAX_BATCH_ROWS: 10
     hosted:
       API_INTEGRATION: AWS_LIVEQUERY
       EXTERNAL_FUNCTION_URI: dlcb3tpiz8.execute-api.us-east-1.amazonaws.com/hosted/
       ROLES:
         - DATA_READER
+      MAX_BATCH_ROWS: 10

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -73,7 +73,7 @@ vars:
   # The keys correspond to dbt profiles and are case sensitive
     dev:
       API_INTEGRATION: AWS_LIVE_QUERY_STG
-      EXTERNAL_FUNCTION_URI: u5z0tu43sc.execute-api.us-east-1.amazonaws.com/stg/
+      EXTERNAL_FUNCTION_URI: yn4219e0o6.execute-api.us-east-1.amazonaws.com/stg/
       ROLES:
         - INTERNAL_DEV
       MAX_BATCH_ROWS: 10

--- a/macros/core/_live.yaml.sql
+++ b/macros/core/_live.yaml.sql
@@ -1,5 +1,21 @@
 {% macro config_core__live(schema="_live") %}
 
+- name: {{ schema }}.udf_api_batched
+  signature:
+    - [method, STRING]
+    - [url, STRING]
+    - [headers, OBJECT]
+    - [DATA, VARIANT]
+    - [user_id, STRING]
+    - [SECRET, STRING]
+  return_type: VARIANT
+  func_type: EXTERNAL
+  api_integration: '{{ var("API_INTEGRATION") }}'
+  max_batch_rows: '{{ var("MAX_BATCH_ROWS") }}'
+  options: |
+    NOT NULL
+  sql: udf_api
+
 - name: {{ schema }}.udf_api
   signature:
     - [method, STRING]
@@ -14,4 +30,5 @@
   options: |
     NOT NULL
   sql: udf_api
+
 {% endmacro %}

--- a/macros/core/live.yaml.sql
+++ b/macros/core/live.yaml.sql
@@ -131,4 +131,26 @@
     VOLATILE
     COMMENT = $$Returns a list of allowed domains.$$
   sql: allowed
+
+- name: {{ schema }}.udf_api_batched
+  signature:
+    - [method, STRING]
+    - [url, STRING]
+    - [headers, OBJECT]
+    - [data, VARIANT]
+    - [secret_name, STRING]
+  return_type: VARIANT
+  options: |
+    VOLATILE
+    MAX_BATCH_ROWS = 2
+  sql: |
+    SELECT
+      _live.UDF_API(
+          method,
+          url,
+          headers,
+          data,
+          _utils.UDF_WHOAMI(),
+          secret_name
+      )
 {% endmacro %}

--- a/macros/core/live.yaml.sql
+++ b/macros/core/live.yaml.sql
@@ -1,5 +1,26 @@
 {% macro config_core_live(schema="live") %}
 
+- name: {{ schema }}.udf_api_batched
+  signature:
+    - [method, STRING]
+    - [url, STRING]
+    - [headers, OBJECT]
+    - [data, VARIANT]
+    - [secret_name, STRING]
+  return_type: VARIANT
+  options: |
+    VOLATILE
+  sql: |
+    SELECT
+      _live.UDF_API(
+          method,
+          url,
+          headers,
+          data,
+          _utils.UDF_WHOAMI(),
+          secret_name
+      )
+
 - name: {{ schema }}.udf_api
   signature:
     - [method, STRING]
@@ -131,26 +152,4 @@
     VOLATILE
     COMMENT = $$Returns a list of allowed domains.$$
   sql: allowed
-
-- name: {{ schema }}.udf_api_batched
-  signature:
-    - [method, STRING]
-    - [url, STRING]
-    - [headers, OBJECT]
-    - [data, VARIANT]
-    - [secret_name, STRING]
-  return_type: VARIANT
-  options: |
-    VOLATILE
-    MAX_BATCH_ROWS = 2
-  sql: |
-    SELECT
-      _live.UDF_API(
-          method,
-          url,
-          headers,
-          data,
-          _utils.UDF_WHOAMI(),
-          secret_name
-      )
 {% endmacro %}

--- a/macros/livequery/manage_udfs.sql
+++ b/macros/livequery/manage_udfs.sql
@@ -33,7 +33,8 @@
         sql_,
         api_integration = none,
         options = none,
-        func_type = none
+        func_type = none,
+        max_batch_rows = none
     ) %}
     CREATE OR REPLACE {{ func_type }} FUNCTION {{ name_ }}(
             {{- livequery_models.compile_signature(signature) }}
@@ -44,9 +45,12 @@
         {{ options }}
     {% endif %}
     {%- if api_integration -%}
-    api_integration = {{ api_integration }}
-    AS {{ livequery_models.construct_api_route(sql_) ~ ";" }}
-    {% else -%}
+    api_integration = {{ api_integration -}}
+    {%- if max_batch_rows -%}
+    {{ "\n    max_batch_rows = " ~ max_batch_rows -}}
+    {%- endif -%}
+    {{ "\n    AS " ~ livequery_models.construct_api_route(sql_) ~ ";" -}}
+    {%- else -%}
     AS
     $$
     {{ sql_ }}
@@ -65,7 +69,7 @@
     {% set options = config ["options"] %}
     {% set api_integration = config ["api_integration"] %}
     {% set func_type = config ["func_type"] %}
-
+    {% set max_batch_rows = config ["max_batch_rows"] %}
     {% if not drop_ -%}
         {{ livequery_models.create_sql_function(
             name_ = name_,
@@ -74,6 +78,7 @@
             sql_ = sql_,
             options = options,
             api_integration = api_integration,
+            max_batch_rows = max_batch_rows,
             func_type = func_type
         ) }}
     {%- else -%}

--- a/models/deploy/core/live.yml
+++ b/models/deploy/core/live.yml
@@ -2,6 +2,57 @@ version: 2
 models:
   - name: live
     columns:
+      - name: udf_api_batched
+        tests:
+          - test_udf:
+              name: test__live_udf_api_batched_post_data_object
+              args: |
+                'GET', 
+                'https://httpbin.org/get', 
+                {'Content-Type': 'application/json'}, 
+                {'param1': 'value1', 'param2': 'value2'}, 
+                ''
+              assertions:
+                - result:status_code = 200
+                - result:data.args is not null
+                - result:data.args:param1 = 'value1'
+                - result:data.args:param2 = 'value2'
+          - test_udf:
+              name: test__live_udf_api_batched_post_jsonrpc_ethereum_batch
+              args: |
+                'POST',
+                'https://ethereum-rpc.publicnode.com',
+                {'Content-Type': 'application/json'},
+                [
+                  {'jsonrpc': '2.0', 'id': 1, 'method': 'eth_blockNumber', 'params': []},
+                  {'jsonrpc': '2.0', 'id': 2, 'method': 'eth_chainId', 'params': []}
+                ],
+                ''
+              assertions:
+                - result:status_code = 200
+                - result:data[0]:jsonrpc = '2.0'
+                - result:data[0]:id = 1
+                - result:data[0]:result is not null
+                - result:data[1]:jsonrpc = '2.0'
+                - result:data[1]:id = 2
+                - result:data[1]:result = '0x1'
+          - test_udf:
+              name: test__live_udf_api_batched_post_jsonrpc_solana
+              args: |
+                'POST',
+                'https://api.mainnet-beta.solana.com',
+                {'Content-Type': 'application/json'},
+                {
+                  'jsonrpc': '2.0',
+                  'id': 1,
+                  'method': 'getVersion'
+                },
+                ''
+              assertions:
+                - result:status_code = 200
+                - result:data.jsonrpc = '2.0'
+                - result:data.id = 1
+                - result:data.result is not null
       - name: udf_api
         tests:
           - test_udf:


### PR DESCRIPTION
This PR introduces a new UDF configuration named `udf_api_batched` and extends existing macros to support batched API calls by adding a new parameter `max_batch_rows`.

- Updated macros in livequery and core directories to include "max_batch_rows" in function definitions
- Added new `udf_api_batched` UDF configurations for `_live`
  - Mapped signature overload for `udf_api_batched` from `live` 
- Updated `dbt_project.yml` and Makefile to support the new UDF configuration and deployment process
  - Updated `EXTERNAL_FUNCTION_URI` for the `AWS_LIVE_QUERY_STG` integration
  - Added deploy core make directive
  
  Success deployment of [livequery_dev._live.udf_api_batched](https://app.snowflake.com/zsniary/exa10207/#/data/databases/LIVEQUERY_DEV/schemas/_LIVE/user-function/UDF_API_BATCHED(VARCHAR%2C%20VARCHAR%2C%20OBJECT%2C%20VARIANT%2C%20VARCHAR%2C%20VARCHAR))
  
  Successful tests:
  
  
![image](https://github.com/user-attachments/assets/761aef44-6912-40b3-b6f3-6a4b0ac8e285)
